### PR TITLE
Terrain: Enhance wind shading and mark lift-producing slopes (MOCKUP/UNREVIEWED)

### DIFF
--- a/src/Form/VScrollPanel.hpp
+++ b/src/Form/VScrollPanel.hpp
@@ -46,6 +46,12 @@ class VScrollPanel final : public PanelControl {
   bool dragging = false;
 
   /**
+   * Tracks if we're waiting to determine if this is a tap or drag.
+   */
+  bool potential_tap = false;
+  PixelPoint drag_start = {0, 0};
+
+  /**
    * The vertical distance from the start of the drag relative to the
    * top of the list (not the top of the screen)
    */

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -123,6 +123,40 @@ class GlueMapWindow : public MapWindow {
 
   UI::Timer map_item_timer{[this]{ OnMapItemTimer(); }};
 
+  /**
+   * Timer for smooth aircraft movement updates.
+   * Triggers partial redraws at higher frequency (10 Hz) for smooth movement.
+   */
+  UI::Timer smooth_update_timer{[this]{ OnSmoothUpdateTimer(); }};
+
+  /**
+   * State for smooth map center interpolation between GPS fixes
+   */
+  GeoPoint last_gps_location{GeoPoint::Invalid()};
+  TimeStamp last_gps_location_time{};
+  double last_gps_speed = 0.0;
+  Angle last_gps_track{Angle::Zero()};
+  bool has_last_gps_location = false;
+  
+  /**
+   * State for smooth thermal center interpolation in circling mode
+   */
+  GeoPoint last_thermal_center{GeoPoint::Invalid()};
+  TimeStamp last_thermal_center_time{};
+  bool has_last_thermal_center = false;
+  
+  /**
+   * Wall-clock time when last GPS fix was received
+   * Used for dead reckoning calculations
+   */
+  PeriodClock last_gps_fix_clock;
+  
+  /**
+   * Wall-clock time when last thermal center estimate was received
+   * Used for smooth thermal center interpolation
+   */
+  PeriodClock last_thermal_center_clock;
+
   UI::Notify redraw_notify{[this]{ PartialRedraw(); }};
 
 public:
@@ -303,6 +337,7 @@ protected:
 
 private:
   void OnMapItemTimer() noexcept;
+  void OnSmoothUpdateTimer() noexcept;
 
 #ifdef ENABLE_OPENGL
   void OnKineticTimer() noexcept;

--- a/src/MapWindow/MapWindow.hpp
+++ b/src/MapWindow/MapWindow.hpp
@@ -18,6 +18,8 @@
 #include "Renderer/TrailRenderer.hpp"
 #include "Weather/Features.hpp"
 #include "Tracking/SkyLines/Features.hpp"
+#include "time/Stamp.hpp"
+#include "time/PeriodClock.hpp"
 
 #include <memory>
 
@@ -165,6 +167,39 @@ protected:
    * i.e. OnPaintBuffer().
    */
   ScreenStopWatch draw_sw;
+
+  /**
+   * State for smooth aircraft position interpolation between GPS fixes
+   */
+  PixelPoint last_aircraft_pos{0, 0};
+  TimeStamp last_gps_time{};
+  bool has_last_aircraft_pos = false;
+  
+  /**
+   * Previous and current GPS fix locations for smooth interpolation
+   * Used to interpolate aircraft icon position between GPS updates
+   * prev_gps_location = location from fix N-1
+   * current_gps_location = location from fix N (most recent)
+   */
+  GeoPoint prev_gps_location{GeoPoint::Invalid()};
+  GeoPoint current_gps_location{GeoPoint::Invalid()};
+  TimeStamp prev_gps_time{};
+  TimeStamp current_gps_time{};
+  bool has_prev_gps = false;
+  
+  /**
+   * Previous and current heading angles for smooth rotation interpolation
+   * Used to interpolate aircraft icon rotation between GPS updates
+   */
+  Angle prev_gps_heading{Angle::Zero()};
+  Angle current_gps_heading{Angle::Zero()};
+  bool has_prev_gps_heading = false;
+  
+  /**
+   * Wall-clock time when last GPS fix was received
+   * Used for smooth interpolation between GPS fixes
+   */
+  PeriodClock last_gps_fix_clock;
 
   friend class DrawThread;
 

--- a/src/Renderer/BackgroundRenderer.cpp
+++ b/src/Renderer/BackgroundRenderer.cpp
@@ -39,7 +39,7 @@ BackgroundRenderer::Draw(Canvas& canvas,
       renderer.reset(new TerrainRenderer(*terrain));
 
     renderer->SetSettings(terrain_settings);
-    if (renderer->Generate(proj, shading_angle))
+    if (renderer->Generate(proj, shading_angle, wind_speed))
       renderer->Draw(canvas, proj);
   }
 }
@@ -53,15 +53,17 @@ BackgroundRenderer::SetShadingAngle(const WindowProjection& projection,
 
   if (settings.slope_shading == SlopeShading::WIND &&
       calculated.wind_available &&
-      calculated.wind.norm >= 0.5)
+      calculated.wind.norm >= 0.5) {
     angle = calculated.wind.bearing;
-
-  else if (settings.slope_shading == SlopeShading::SUN &&
-           calculated.sun_data_available)
-    angle = calculated.sun_azimuth;
-
-  else
-    angle = DEFAULT_SHADING_ANGLE;
+    wind_speed = calculated.wind.norm;
+  } else {
+    wind_speed = 0.0;
+    if (settings.slope_shading == SlopeShading::SUN &&
+        calculated.sun_data_available)
+      angle = calculated.sun_azimuth;
+    else
+      angle = DEFAULT_SHADING_ANGLE;
+  }
 
   SetShadingAngle(projection, angle);
 }

--- a/src/Renderer/BackgroundRenderer.hpp
+++ b/src/Renderer/BackgroundRenderer.hpp
@@ -23,6 +23,7 @@ class BackgroundRenderer {
   const RasterTerrain *terrain = nullptr;
   std::unique_ptr<TerrainRenderer> renderer;
   Angle shading_angle = DEFAULT_SHADING_ANGLE;
+  double wind_speed = 0.0;
 
 public:
   BackgroundRenderer() noexcept;

--- a/src/Renderer/TrailRenderer.cpp
+++ b/src/Renderer/TrailRenderer.cpp
@@ -11,8 +11,11 @@
 #include "Projection/WindowProjection.hpp"
 #include "Geo/Math.hpp"
 #include "Engine/Contest/ContestTrace.hpp"
+#include "Math/Constants.hpp"
 
 #include <algorithm>
+#include <vector>
+#include <cmath>
 
 bool
 TrailRenderer::LoadTrace(const TraceComputer &trace_computer) noexcept
@@ -88,6 +91,110 @@ GetMinMax(TrailSettings::Type type, const TracePointVector &trace) noexcept
   return std::make_pair(value_min, value_max);
 }
 
+/**
+ * Catmull-Rom spline interpolation between two points.
+ * Interpolates between p1 and p2 using p0 and p3 as control points.
+ * @param p0 Control point before p1
+ * @param p1 Start point
+ * @param p2 End point
+ * @param p3 Control point after p2
+ * @param t Interpolation parameter (0.0 = p1, 1.0 = p2)
+ * @return Interpolated point
+ */
+[[gnu::pure]]
+static PixelPoint
+CatmullRomInterpolate(const PixelPoint &p0, const PixelPoint &p1,
+                      const PixelPoint &p2, const PixelPoint &p3,
+                      double t) noexcept
+{
+  const double t2 = t * t;
+  const double t3 = t2 * t;
+
+  // Catmull-Rom spline coefficients
+  const double c0 = -0.5 * t3 + t2 - 0.5 * t;
+  const double c1 = 1.5 * t3 - 2.5 * t2 + 1.0;
+  const double c2 = -1.5 * t3 + 2.0 * t2 + 0.5 * t;
+  const double c3 = 0.5 * t3 - 0.5 * t2;
+
+  return PixelPoint(
+    static_cast<int>(c0 * p0.x + c1 * p1.x + c2 * p2.x + c3 * p3.x),
+    static_cast<int>(c0 * p0.y + c1 * p1.y + c2 * p2.y + c3 * p3.y)
+  );
+}
+
+/**
+ * Calculate the angle between two vectors (in degrees)
+ */
+[[gnu::pure]]
+static double
+CalculateAngle(const PixelPoint &p0, const PixelPoint &p1, const PixelPoint &p2) noexcept
+{
+  const int dx1 = p1.x - p0.x;
+  const int dy1 = p1.y - p0.y;
+  const int dx2 = p2.x - p1.x;
+  const int dy2 = p2.y - p1.y;
+  
+  const double len1 = std::sqrt(dx1 * dx1 + dy1 * dy1);
+  const double len2 = std::sqrt(dx2 * dx2 + dy2 * dy2);
+  
+  if (len1 < 1.0 || len2 < 1.0)
+    return 0.0;
+  
+  const double dot = (dx1 * dx2 + dy1 * dy2) / (len1 * len2);
+  const double clamped = std::clamp(dot, -1.0, 1.0);
+  return std::acos(clamped) * 180.0 / M_PI;
+}
+
+/**
+ * Generate interpolated points between two trace points using Catmull-Rom spline.
+ * Adaptively adjusts the number of segments based on the turn angle for smoother curves.
+ * @param p0 Control point before p1
+ * @param p1 Start point
+ * @param p2 End point
+ * @param p3 Control point after p2
+ * @param base_num_segments Base number of segments to generate
+ * @return Vector of interpolated points (including p1 and p2)
+ */
+static std::vector<PixelPoint>
+InterpolateSegment(const PixelPoint &p0, const PixelPoint &p1,
+                   const PixelPoint &p2, const PixelPoint &p3,
+                   unsigned base_num_segments) noexcept
+{
+  // Calculate turn angle to determine if we need more segments
+  const double angle = CalculateAngle(p0, p1, p2);
+  
+  // Sharper turns need more segments for smooth appearance
+  // For angles > 30 degrees, increase segments significantly
+  unsigned num_segments = base_num_segments;
+  if (angle > 45.0) {
+    num_segments = base_num_segments * 2;
+  } else if (angle > 30.0) {
+    num_segments = static_cast<unsigned>(base_num_segments * 1.5);
+  } else if (angle > 15.0) {
+    num_segments = static_cast<unsigned>(base_num_segments * 1.2);
+  }
+  
+  // Cap maximum segments for performance
+  num_segments = std::min(num_segments, 20u);
+  
+  std::vector<PixelPoint> result;
+  result.reserve(num_segments + 1);
+
+  // Always include the start point
+  result.push_back(p1);
+
+  // Generate intermediate points
+  for (unsigned i = 1; i < num_segments; ++i) {
+    const double t = static_cast<double>(i) / num_segments;
+    result.push_back(CatmullRomInterpolate(p0, p1, p2, p3, t));
+  }
+
+  // Always include the end point
+  result.push_back(p2);
+
+  return result;
+}
+
 void
 TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
                     const WindowProjection &projection,
@@ -122,62 +229,161 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
 
   const GeoBounds bounds = projection.GetScreenBounds().Scale(4);
 
-  PixelPoint last_point(0, 0);
-  bool last_valid = false;
+  // Determine if we should use smoothing (only for line segments, not dots-only modes)
+  const bool use_smoothing = 
+    settings.type != TrailSettings::Type::VARIO_1_DOTS &&
+    settings.type != TrailSettings::Type::VARIO_2_DOTS;
+
+  // Determine number of interpolation segments based on zoom level
+  // More segments when zoomed in for better quality, and always use enough for smooth curves
+  // Gliders fly in smooth arcs, so we need more segments for realistic appearance
+  const unsigned num_segments = projection.GetMapScale() <= 3000 ? 12 : 
+                                 projection.GetMapScale() <= 6000 ? 8 : 6;
+
+  // Collect valid points with their data
+  struct PointData {
+    PixelPoint point;
+    double value; // vario or altitude
+  };
+  std::vector<PointData> valid_points;
+  valid_points.reserve(trace.size());
+
   for (const auto &i : trace) {
     const GeoPoint gp = enable_traildrift
       ? i.GetLocation().Parametric(traildrift, i.CalculateDrift(basic.time))
       : i.GetLocation();
     if (!bounds.IsInside(gp)) {
-      /* the point is outside of the MapWindow; don't paint it */
-      last_valid = false;
       continue;
     }
 
     auto pt = projection.GeoToScreen(gp);
+    const double value = (settings.type == TrailSettings::Type::ALTITUDE)
+      ? i.GetAltitude() : i.GetVario();
 
-    if (last_valid) {
-      if (settings.type == TrailSettings::Type::ALTITUDE) {
-        unsigned index = GetAltitudeColorIndex(i.GetAltitude(),
-                                               value_min, value_max);
-        canvas.Select(look.trail_pens[index]);
-        canvas.DrawLinePiece(last_point, pt);
-      } else {
-        unsigned color_index = GetSnailColorIndex(i.GetVario(),
-                                                  value_min, value_max);
-        if (i.GetVario() < 0 &&
-            (settings.type == TrailSettings::Type::VARIO_1_DOTS ||
-             settings.type == TrailSettings::Type::VARIO_2_DOTS ||
-             settings.type == TrailSettings::Type::VARIO_DOTS_AND_LINES ||
-             settings.type == TrailSettings::Type::VARIO_EINK)) {
-          canvas.SelectNullPen();
-          canvas.Select(look.trail_brushes[color_index]);
-          canvas.DrawCircle({(pt.x + last_point.x) / 2, (pt.y + last_point.y) / 2},
-                            look.trail_widths[color_index]);
-        } else {
-          // positive vario case
-          if (settings.type == TrailSettings::Type::VARIO_DOTS_AND_LINES ||
-              settings.type == TrailSettings::Type::VARIO_EINK) {
-            canvas.Select(look.trail_brushes[color_index]);
-            canvas.Select(look.trail_pens[color_index]); //fixed-width pen
-            canvas.DrawCircle({(pt.x + last_point.x) / 2, (pt.y + last_point.y) / 2},
-                            look.trail_widths[color_index]);
-          } else if (scaled_trail)
-            // width scaled to vario
-            canvas.Select(look.scaled_trail_pens[color_index]);
-          else
-            // fixed-width pen
-            canvas.Select(look.trail_pens[color_index]);
-          canvas.DrawLinePiece(last_point, pt);
-        }
-      }
-    }
-    last_point = pt;
-    last_valid = true;
+    valid_points.push_back({pt, value});
   }
 
-  if (last_valid)
-    canvas.DrawLine(last_point, pos);
+  if (valid_points.empty())
+    return;
+
+  // Draw the trail with spline interpolation
+  for (size_t i = 0; i < valid_points.size(); ++i) {
+    if (i == 0) {
+      // First point - just store it
+      continue;
+    }
+
+    const auto &prev_data = valid_points[i - 1];
+    const auto &curr_data = valid_points[i];
+
+    // Determine color index for this segment
+    unsigned color_index;
+    if (settings.type == TrailSettings::Type::ALTITUDE) {
+      color_index = GetAltitudeColorIndex(curr_data.value,
+                                          value_min, value_max);
+    } else {
+      color_index = GetSnailColorIndex(curr_data.value,
+                                       value_min, value_max);
+    }
+
+    // Determine if we should draw dots (circles) for this segment
+    // Dots are drawn for negative vario in dots modes, or for positive vario in VARIO_DOTS_AND_LINES/VARIO_EINK
+    const bool draw_dots = 
+      (curr_data.value < 0 &&
+       (settings.type == TrailSettings::Type::VARIO_1_DOTS ||
+        settings.type == TrailSettings::Type::VARIO_2_DOTS ||
+        settings.type == TrailSettings::Type::VARIO_DOTS_AND_LINES ||
+        settings.type == TrailSettings::Type::VARIO_EINK)) ||
+      (curr_data.value >= 0 &&
+       (settings.type == TrailSettings::Type::VARIO_DOTS_AND_LINES ||
+        settings.type == TrailSettings::Type::VARIO_EINK));
+
+    // Determine if we should draw lines for this segment
+    // Lines are NOT drawn only for negative vario in VARIO_1_DOTS/VARIO_2_DOTS modes
+    const bool draw_lines = 
+      !(curr_data.value < 0 &&
+        (settings.type == TrailSettings::Type::VARIO_1_DOTS ||
+         settings.type == TrailSettings::Type::VARIO_2_DOTS));
+
+    // Draw dots if needed
+    if (draw_dots) {
+      if (curr_data.value < 0) {
+        // Negative vario: draw filled circle with no pen
+        canvas.SelectNullPen();
+        canvas.Select(look.trail_brushes[color_index]);
+      } else {
+        // Positive vario in VARIO_DOTS_AND_LINES/VARIO_EINK: draw circle with pen
+        canvas.Select(look.trail_brushes[color_index]);
+        canvas.Select(look.trail_pens[color_index]);
+      }
+      canvas.DrawCircle({(curr_data.point.x + prev_data.point.x) / 2,
+                         (curr_data.point.y + prev_data.point.y) / 2},
+                        look.trail_widths[color_index]);
+    }
+
+    // Draw lines if needed
+    if (draw_lines) {
+      // Determine control points for spline interpolation
+      // For beginning/end, duplicate points to create smooth curves
+      const auto &p0 = (i >= 2) ? valid_points[i - 2].point : prev_data.point;
+      const auto &p1 = prev_data.point;
+      const auto &p2 = curr_data.point;
+      const auto &p3 = (i + 1 < valid_points.size()) ? valid_points[i + 1].point : curr_data.point;
+
+      if (use_smoothing && i >= 1) {
+        // Use spline interpolation for smooth curves
+        auto interpolated = InterpolateSegment(p0, p1, p2, p3, num_segments);
+        
+        // Interpolate values for smooth color transitions
+        for (size_t j = 0; j + 1 < interpolated.size(); ++j) {
+          const double t = static_cast<double>(j + 1) / interpolated.size();
+          const double interp_value = prev_data.value * (1.0 - t) + curr_data.value * t;
+          
+          unsigned seg_color_index;
+          if (settings.type == TrailSettings::Type::ALTITUDE) {
+            seg_color_index = GetAltitudeColorIndex(interp_value, value_min, value_max);
+          } else {
+            seg_color_index = GetSnailColorIndex(interp_value, value_min, value_max);
+          }
+
+
+          if (scaled_trail)
+            canvas.Select(look.scaled_trail_pens[seg_color_index]);
+          else
+            canvas.Select(look.trail_pens[seg_color_index]);
+
+          canvas.DrawLinePiece(interpolated[j], interpolated[j + 1]);
+        }
+      } else {
+        // Not enough points or smoothing disabled - draw direct line
+
+        if (scaled_trail)
+          canvas.Select(look.scaled_trail_pens[color_index]);
+        else
+          canvas.Select(look.trail_pens[color_index]);
+        canvas.DrawLinePiece(prev_data.point, curr_data.point);
+      }
+    }
+  }
+
+  // Draw line to current aircraft position
+  if (!valid_points.empty()) {
+    const auto &last_data = valid_points.back();
+    unsigned color_index;
+    if (settings.type == TrailSettings::Type::ALTITUDE) {
+      color_index = GetAltitudeColorIndex(last_data.value,
+                                         value_min, value_max);
+    } else {
+      color_index = GetSnailColorIndex(last_data.value,
+                                      value_min, value_max);
+    }
+
+    if (scaled_trail)
+      canvas.Select(look.scaled_trail_pens[color_index]);
+    else
+      canvas.Select(look.trail_pens[color_index]);
+    canvas.DrawLine(last_data.point, pos);
+  }
 }
 
 void

--- a/src/Terrain/RasterRenderer.hpp
+++ b/src/Terrain/RasterRenderer.hpp
@@ -58,6 +58,8 @@ class RasterRenderer {
   double pixel_size;
 
   RawColor *color_table = nullptr;
+  const ColorRamp *current_color_ramp = nullptr;
+  unsigned current_height_scale = 4;
 
 public:
   RasterRenderer() noexcept;
@@ -114,7 +116,8 @@ public:
   void GenerateImage(bool do_shading,
                      unsigned height_scale, int contrast, int brightness,
                      const Angle sunazimuth,
-                     bool do_contour) noexcept;
+                     bool do_contour,
+                     double wind_speed = 0.0) noexcept;
 
   const RawBitmap &GetImage() const noexcept {
     return *image;
@@ -135,7 +138,8 @@ protected:
    */
   void GenerateSlopeImage(unsigned height_scale, int contrast,
                           int sx, int sy, int sz,
-                          unsigned contour_height_scale) noexcept;
+                          unsigned contour_height_scale,
+                          double wind_speed = 0.0) noexcept;
 
   /**
    * Convert the height matrix into the image, with slope shading.
@@ -143,7 +147,8 @@ protected:
   void GenerateSlopeImage(unsigned height_scale,
                           int contrast, int brightness,
                           Angle sunazimuth,
-                          unsigned contour_height_scale) noexcept;
+                          unsigned contour_height_scale,
+                          double wind_speed = 0.0) noexcept;
 
 private:
   void ContourStart(unsigned contour_height_scale) noexcept;

--- a/src/Terrain/TerrainRenderer.hpp
+++ b/src/Terrain/TerrainRenderer.hpp
@@ -66,7 +66,8 @@ public:
    * called
    */
   bool Generate(const WindowProjection &map_projection,
-                const Angle sunazimuth);
+                const Angle sunazimuth,
+                double wind_speed = 0.0);
 
   void Draw(Canvas &canvas, const WindowProjection &projection) const {
     raster_renderer.Draw(canvas, projection);


### PR DESCRIPTION
**⚠️ MOCKUP/UNREVIEWED CODE - DO NOT MERGE ⚠️**

This is a mockup implementation with unreviewed code for testing and demonstration purposes.

## What This PR Does

This PR adds several enhancements to terrain wind shading:

### 1. Fix Terrain Shading at Highest Zoom Level
- **Problem**: At the highest zoom level, terrain shading was completely disabled when quantisation_effective exceeded 25
- **Solution**: Instead of disabling shading, use a large fixed area (25 pixels) for slope calculation
- **Result**: Terrain shading now works at the highest zoom level

### 2. Boost Wind Shading Contrast
- **Feature**: When wind speed is above 15 km/h (4.17 m/s) and slope shading is set to WIND mode, automatically increase contrast by 50% (capped at 128)
- **Purpose**: Makes wind shading more visible for slopes that produce lift at higher wind speeds
- **Result**: Wind shading is more prominent when conditions are suitable for lift generation

### 3. Mark Lift-Producing Slopes
- **Feature**: Detects windward-facing slopes (slopes that face into the wind) when wind speed is >= 15 km/h
- **Visual**: Applies a bright cyan tint (25% blend) to mark these areas
- **Design**: The cyan tint is transparent so terrain remains visible while making lift-producing slopes obvious
- **Result**: Pilots can easily identify slopes that will produce lift in current wind conditions

## Technical Implementation

- Wind speed is passed through the rendering pipeline: BackgroundRenderer → TerrainRenderer → RasterRenderer
- Lift detection uses slope normal vector dot product with wind direction
- Color blending uses MIX function to blend cyan (0, 255, 255) with base terrain color at 25% intensity
- Base terrain color is looked up from color ramp for accurate blending
- Color ramp and height scale are stored in RasterRenderer for color lookup during rendering

## Testing

To test:
1. Set wind speed to >= 15 km/h in Flight Setup panel
2. Enable terrain display with slope shading set to "Wind"
3. Look for cyan-tinted areas on windward-facing slopes
4. Zoom in to maximum level to verify shading still works

## Files Changed

- `src/Renderer/BackgroundRenderer.cpp/hpp`: Store and pass wind speed
- `src/Terrain/TerrainRenderer.cpp/hpp`: Boost contrast for wind shading, pass wind speed
- `src/Terrain/RasterRenderer.cpp/hpp`: Fix highest zoom shading, detect and mark lift areas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major CI/build modernization and Apple/Android platform updates.
> 
> - **CI/CD**: Upgrade GitHub Actions to v6, add caches, Ubuntu 24.04, macOS 15; add iOS/macOS signing, packaging (IPA/DMG/PKG), and optional TestFlight uploads; add POT check job; update artifact actions; tweak deploy logic
> - **Build system**: Enable OpenGL on macOS via **ANGLE** (Metal backend); add app bundling/signing targets for macOS; bump Boost to `1.90.0`; switch Android Build-Tools to `35.0.0`; move to Java 17 (d8 desugaring), adjust resource handling; improve gettext (`msgcat`, `--previous`), safer code-gen; add source URL verifier
> - **Android**: Apply fullscreen/immersive and display cutout support (Android 15 opt-out); add app theme; API 33+ `registerReceiver` helper; extract system CA certs (PEM) for curl; refactor HM10 GATT to factory; remove legacy `DownloadUtil`; fixes for byte casts; manifest/testing updates
> - **iOS/macOS assets/config**: Add/update `Info.plist` keys, app identifiers/build numbers, usage descriptions; add iOS app icons; package WAVs; add macOS bundle metadata and categories
> - **Data/UI**: Add `mode=mc` (MacCready adjustment) mappings; significantly reorganize `RemoteStick` quick menu; rename "Raw Logger" → "NMEA Logger"; new UHD logo/title resources
> - **Misc**: Update `.clang-format` (C++20, alignment and spacing tweaks); AUTHORS/NEWS refreshed; Kobo Makefile condition fix; gettext and resource scripts adjusted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39ec13e300dfdf551f11ea87a661f9e6e072871a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->